### PR TITLE
gmarchetti/free host port tracker

### DIFF
--- a/commons/docker_manager.go
+++ b/commons/docker_manager.go
@@ -75,6 +75,7 @@ func (manager *DockerManager) GetContainerHostConfig(serviceConfig JsonRpcServic
 	}
 
 	httpPort, err := nat.NewPort("tcp", strconv.Itoa(serviceConfig.GetJsonRpcPort()))
+	// TODO cycle through serviceConfig.getOtherPorts to bind every one, not just gecko staking port
 	stakingPort, err := nat.NewPort("tcp", strconv.Itoa(serviceConfig.GetOtherPorts()[0]))
 	containerHostConfigPtr := &container.HostConfig{
 		PortBindings: nat.PortMap{

--- a/commons/docker_manager.go
+++ b/commons/docker_manager.go
@@ -30,7 +30,10 @@ func (manager DockerManager) GetFreePort() (freePort *nat.Port, err error) {
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "")
 	}
-	port := nat.Port(strconv.Itoa(freePortInt) + "/tcp")
+	port, err := nat.NewPort("tcp", strconv.Itoa(freePortInt))
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
 	return &port, nil
 }
 

--- a/commons/docker_manager.go
+++ b/commons/docker_manager.go
@@ -2,6 +2,7 @@ package commons
 
 import (
 	"context"
+	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/docker/go-connections/nat"
 	"github.com/palantir/stacktrace"
@@ -11,21 +12,25 @@ import (
 // TODO TODO TODO - do we ever need to handle different local host IPs?
 const LOCAL_HOST_IP = "0.0.0.0"
 
+// TODO TODO TODO get these from serviceconfig
+const DEFAULT_GECKO_HTTP_PORT = nat.Port("9650/tcp")
+const DEFAULT_GECKO_STAKING_PORT = nat.Port("9651/tcp")
+
 type DockerManager struct {
-	DockerCtx context.Context
-	DockerClient *client.Client
+	dockerCtx           context.Context
+	dockerClient        *client.Client
 	freeHostPortTracker *FreeHostPortTracker
 }
 
 func NewDockerManager(dockerCtx context.Context, dockerClient *client.Client, hostPortRangeStart int, hostPortRangeEnd int) *DockerManager {
 	return &DockerManager{
-		DockerCtx: dockerCtx,
-		DockerClient: dockerClient,
+		dockerCtx:           dockerCtx,
+		dockerClient:        dockerClient,
 		freeHostPortTracker: NewFreeHostPortTracker(hostPortRangeStart, hostPortRangeEnd),
 	}
 }
 
-func (manager DockerManager) GetFreePort() (freePort *nat.Port, err error) {
+func (manager DockerManager) getFreePort() (freePort *nat.Port, err error) {
 	freePortInt, err := manager.freeHostPortTracker.GetFreePort()
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "")
@@ -37,6 +42,45 @@ func (manager DockerManager) GetFreePort() (freePort *nat.Port, err error) {
 	return &port, nil
 }
 
-func (manager DockerManager) GetLocalHostIp() string {
+func (manager DockerManager) getLocalHostIp() string {
 	return LOCAL_HOST_IP
+}
+
+// Creates a Docker-Container-To-Host Port mapping, defining how a Container's JSON RPC and service-specific ports are
+// mapped to the host ports
+func (manager *DockerManager) GetContainerHostConfig(serviceConfig JsonRpcServiceConfig) (hostConfig *container.HostConfig, err error) {
+	freeRpcPort, err := manager.getFreePort()
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
+	// TODO right nwo this is hardcoded - replace these with FreeHostPortProvider in the future, so we can have
+	//  arbitrary service-specific ports!
+	jsonRpcPortBinding := []nat.PortBinding{
+		{
+			HostIP: manager.getLocalHostIp(),
+			HostPort: freeRpcPort.Port(),
+		},
+	}
+
+	// TODO cycle through serviceConfig.GetOtherPorts to bind every one, not just default gecko staking port
+	freeStakingPort, err := manager.getFreePort()
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
+	stakingPortBinding := []nat.PortBinding{
+		{
+			HostIP: manager.getLocalHostIp(),
+			HostPort: freeStakingPort.Port(),
+		},
+	}
+
+	httpPort, err := nat.NewPort("tcp", strconv.Itoa(serviceConfig.GetJsonRpcPort()))
+	stakingPort, err := nat.NewPort("tcp", strconv.Itoa(serviceConfig.GetOtherPorts()[0]))
+	containerHostConfigPtr := &container.HostConfig{
+		PortBindings: nat.PortMap{
+			httpPort: jsonRpcPortBinding,
+			stakingPort: stakingPortBinding,
+		},
+	}
+	return containerHostConfigPtr, nil
 }

--- a/commons/docker_manager.go
+++ b/commons/docker_manager.go
@@ -1,0 +1,39 @@
+package commons
+
+import (
+	"context"
+	"github.com/docker/docker/client"
+	"github.com/docker/go-connections/nat"
+	"github.com/palantir/stacktrace"
+	"strconv"
+)
+
+// TODO TODO TODO - do we ever need to handle different local host IPs?
+const LOCAL_HOST_IP = "0.0.0.0"
+
+type DockerManager struct {
+	DockerCtx context.Context
+	DockerClient *client.Client
+	freeHostPortTracker *FreeHostPortTracker
+}
+
+func NewDockerManager(dockerCtx context.Context, dockerClient *client.Client, hostPortRangeStart int, hostPortRangeEnd int) *DockerManager {
+	return &DockerManager{
+		DockerCtx: dockerCtx,
+		DockerClient: dockerClient,
+		freeHostPortTracker: NewFreeHostPortTracker(hostPortRangeStart, hostPortRangeEnd),
+	}
+}
+
+func (manager DockerManager) GetFreePort() (freePort *nat.Port, err error) {
+	freePortInt, err := manager.freeHostPortTracker.GetFreePort()
+	if err != nil {
+		return nil, stacktrace.Propagate(err, "")
+	}
+	port := nat.Port(strconv.Itoa(freePortInt) + "/tcp")
+	return &port, nil
+}
+
+func (manager DockerManager) GetLocalHostIp() string {
+	return LOCAL_HOST_IP
+}

--- a/commons/free_host_port_tracker.go
+++ b/commons/free_host_port_tracker.go
@@ -18,8 +18,8 @@ func NewFreeHostPortTracker(portRangeStart int, portRangeEnd int) *FreeHostPortT
 }
 
 func (hostPortTracker FreeHostPortTracker) GetFreePort() (port int, err error) {
-	for port, taken := range hostPortTracker.takenPorts {
-		if !taken {
+	for port := hostPortTracker.PortRangeStart; port < hostPortTracker.PortRangeEnd; port++ {
+		if _, ok := hostPortTracker.takenPorts[port]; !ok {
 			hostPortTracker.takenPorts[port] = true
 			return port, nil
 		}

--- a/commons/free_host_port_tracker.go
+++ b/commons/free_host_port_tracker.go
@@ -36,11 +36,8 @@ func (hostPortTracker FreeHostPortTracker) GetFreePort() (port int, err error) {
 	return -1, stacktrace.NewError("There are no more free ports available given the host port range.")
 }
 
-func (hostPortTracker FreeHostPortTracker) ReleasePort(port int) (err error) {
-	if _, ok := hostPortTracker.takenPorts[port]; ok {
-		delete(hostPortTracker.takenPorts, port)
-	}
-	return nil
+func (hostPortTracker FreeHostPortTracker) ReleasePort(port int) {
+	delete(hostPortTracker.takenPorts, port)
 }
 
 func isPortValid(port int) bool {

--- a/commons/free_host_port_tracker.go
+++ b/commons/free_host_port_tracker.go
@@ -3,22 +3,22 @@ package commons
 import "github.com/palantir/stacktrace"
 
 type FreeHostPortTracker struct {
-	PortRangeStart int
-	PortRangeEnd int
-	takenPorts map[int]bool
+	portRangeStart int
+	portRangeEnd   int
+	takenPorts     map[int]bool
 }
 
 func NewFreeHostPortTracker(portRangeStart int, portRangeEnd int) *FreeHostPortTracker {
 	portMap := make(map[int]bool)
 	return &FreeHostPortTracker{
-		PortRangeStart: portRangeStart,
-		PortRangeEnd: portRangeEnd,
-		takenPorts: portMap,
+		portRangeStart: portRangeStart,
+		portRangeEnd:   portRangeEnd,
+		takenPorts:     portMap,
 	}
 }
 
 func (hostPortTracker FreeHostPortTracker) GetFreePort() (port int, err error) {
-	for port := hostPortTracker.PortRangeStart; port < hostPortTracker.PortRangeEnd; port++ {
+	for port := hostPortTracker.portRangeStart; port < hostPortTracker.portRangeEnd; port++ {
 		if _, ok := hostPortTracker.takenPorts[port]; !ok {
 			hostPortTracker.takenPorts[port] = true
 			return port, nil

--- a/commons/free_host_port_tracker.go
+++ b/commons/free_host_port_tracker.go
@@ -1,0 +1,39 @@
+package commons
+
+import "github.com/palantir/stacktrace"
+
+type FreeHostPortTracker struct {
+	PortRangeStart int
+	PortRangeEnd int
+	takenPorts map[int]bool
+}
+
+func NewFreeHostPortTracker(portRangeStart int, portRangeEnd int) *FreeHostPortTracker {
+	portMap := make(map[int]bool)
+	for i := portRangeStart; i < portRangeEnd; i++ {
+		portMap[i] = false
+	}
+	return &FreeHostPortTracker{
+		PortRangeStart: portRangeStart,
+		PortRangeEnd: portRangeEnd,
+		takenPorts: portMap,
+	}
+}
+
+func (hostPortTracker FreeHostPortTracker) GetFreePort() (port int, err error) {
+	for port, taken := range hostPortTracker.takenPorts {
+		if !taken {
+			hostPortTracker.takenPorts[port] = true
+			return port, nil
+		}
+	}
+	return -1, stacktrace.NewError("There are no more free ports available given the host port range.")
+}
+
+func (hostPortTracker FreeHostPortTracker) ReleasePort(port int) (err error) {
+	if hostPortTracker.takenPorts[port] {
+		hostPortTracker.takenPorts[port] = false
+	}
+	return stacktrace.NewError("Tried to free port %v, but it was already free.", port)
+}
+

--- a/commons/free_host_port_tracker.go
+++ b/commons/free_host_port_tracker.go
@@ -2,19 +2,28 @@ package commons
 
 import "github.com/palantir/stacktrace"
 
+const VALID_PORT_RANGE_START = 1024
+const VALID_PORT_RANGE_END = 65535
+
 type FreeHostPortTracker struct {
 	portRangeStart int
 	portRangeEnd   int
 	takenPorts     map[int]bool
 }
 
-func NewFreeHostPortTracker(portRangeStart int, portRangeEnd int) *FreeHostPortTracker {
+func NewFreeHostPortTracker(portRangeStart int, portRangeEnd int) (freeHostPortTracker *FreeHostPortTracker, err error) {
 	portMap := make(map[int]bool)
+	if portRangeEnd <= portRangeStart {
+		return nil, stacktrace.NewError("FreeHostPortTracker requires end port range greater than start port range.")
+	}
+	if !isPortValid(portRangeStart) || !isPortValid(portRangeEnd) {
+		return nil, stacktrace.NewError("FreeHostPortTracker requires port range between %s and %s, inclusive.", VALID_PORT_RANGE_START, VALID_PORT_RANGE_END)
+	}
 	return &FreeHostPortTracker{
 		portRangeStart: portRangeStart,
 		portRangeEnd:   portRangeEnd,
 		takenPorts:     portMap,
-	}
+	}, nil
 }
 
 func (hostPortTracker FreeHostPortTracker) GetFreePort() (port int, err error) {
@@ -34,3 +43,6 @@ func (hostPortTracker FreeHostPortTracker) ReleasePort(port int) (err error) {
 	return nil
 }
 
+func isPortValid(port int) bool {
+	return port >= VALID_PORT_RANGE_START && port <= VALID_PORT_RANGE_END
+}

--- a/commons/free_host_port_tracker.go
+++ b/commons/free_host_port_tracker.go
@@ -10,9 +10,6 @@ type FreeHostPortTracker struct {
 
 func NewFreeHostPortTracker(portRangeStart int, portRangeEnd int) *FreeHostPortTracker {
 	portMap := make(map[int]bool)
-	for i := portRangeStart; i < portRangeEnd; i++ {
-		portMap[i] = false
-	}
 	return &FreeHostPortTracker{
 		PortRangeStart: portRangeStart,
 		PortRangeEnd: portRangeEnd,
@@ -31,9 +28,9 @@ func (hostPortTracker FreeHostPortTracker) GetFreePort() (port int, err error) {
 }
 
 func (hostPortTracker FreeHostPortTracker) ReleasePort(port int) (err error) {
-	if hostPortTracker.takenPorts[port] {
-		hostPortTracker.takenPorts[port] = false
+	if _, ok := hostPortTracker.takenPorts[port]; ok {
+		delete(hostPortTracker.takenPorts, port)
 	}
-	return stacktrace.NewError("Tried to free port %v, but it was already free.", port)
+	return nil
 }
 

--- a/initializer/test_suite_runner.go
+++ b/initializer/test_suite_runner.go
@@ -3,7 +3,6 @@ package initializer
 import (
 	"context"
 	"os"
-
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
@@ -13,6 +12,9 @@ import (
 
 	"github.com/palantir/stacktrace"
 )
+
+const START_HOST_PORT_RANGE = 9650
+const END_HOST_PORT_RANGE = 9651
 
 
 type TestSuiteRunner struct {
@@ -41,10 +43,12 @@ func (testSuiteRunner TestSuiteRunner) RunTests() (err error) {
 		return stacktrace.Propagate(err,"Failed to initialize Docker client from environment.")
 	}
 
+	dockerManager := commons.NewDockerManager(dockerCtx, dockerClient, START_HOST_PORT_RANGE, END_HOST_PORT_RANGE)
+
 	// TODO implement parallelism and specific test selection here
 	for _, configProvider := range testSuiteRunner.tests {
 		testNetworkCfg := configProvider.GetNetworkConfig()
-		serviceNetwork, err := testNetworkCfg.CreateAndRun(dockerCtx, dockerClient)
+		serviceNetwork, err := testNetworkCfg.CreateAndRun(dockerManager)
 		if err != nil {
 			return stacktrace.Propagate(err,"Failed to create and run test network.")
 		}

--- a/initializer/test_suite_runner.go
+++ b/initializer/test_suite_runner.go
@@ -14,7 +14,7 @@ import (
 )
 
 const START_HOST_PORT_RANGE = 9650
-const END_HOST_PORT_RANGE = 9651
+const END_HOST_PORT_RANGE = 9652
 
 
 type TestSuiteRunner struct {

--- a/initializer/test_suite_runner.go
+++ b/initializer/test_suite_runner.go
@@ -43,7 +43,10 @@ func (testSuiteRunner TestSuiteRunner) RunTests() (err error) {
 		return stacktrace.Propagate(err,"Failed to initialize Docker client from environment.")
 	}
 
-	dockerManager := commons.NewDockerManager(dockerCtx, dockerClient, START_HOST_PORT_RANGE, END_HOST_PORT_RANGE)
+	dockerManager, err := commons.NewDockerManager(dockerCtx, dockerClient, START_HOST_PORT_RANGE, END_HOST_PORT_RANGE)
+	if err != nil {
+		return stacktrace.Propagate(err, "Error in initializing Docker Manager.")
+	}
 
 	// TODO implement parallelism and specific test selection here
 	for _, configProvider := range testSuiteRunner.tests {


### PR DESCRIPTION
Implements a FreeHostPortTracker and a DockerManager, allowing multiple containers to be spun up without incurring host collisions

Resolves https://github.com/galenmarchetti/kurtosis/issues/12 in addition to a week-1 milestone