### PR TITLE
Gmarchetti/pull images from dockerhub

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gmarchetti/kurtosis/commons"
 	"github.com/gmarchetti/kurtosis/initializer"
 	"github.com/palantir/stacktrace"
+	"log"
 )
 
 func main() {
@@ -54,6 +55,7 @@ func main() {
 	}
 
 	if *pullImageFromRepoArg {
+		log.Printf("Pulling image...")
 		dockerManager.PullImageFromRepo(*geckoImageNameArg)
 	}
 


### PR DESCRIPTION
Adds a command line flag to indicate image should be pulled from a repo. Tested with docker hub:

`./build/kurtosis -gecko-image-name avaplatform/gecko:684ca4e --pull-image-from-repo=true`

Required moving docker manager intialization into main.go and then passing it to constructor of test_suite_runner, because this docker manager functionality is about prepping the environment of the docker engine and not about any specific test. seemed to be the cleanest way to do this and not have to implement pulling logic per test network configuration.