### PR TITLE
basic initial travisci script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+dist: xenial
+
+language: go
+go: 1.13.x
+
+services:
+  - docker


### PR DESCRIPTION
this default setup just runs go test on the kurtosis root directory. successful run already here: https://travis-ci.com/github/kurtosis-tech/kurtosis