### PR TITLE
Remove unused networkName from FreeIPAddrTracker

### DIFF
--- a/commons/testnet/public_ip_tracker.go
+++ b/commons/testnet/public_ip_tracker.go
@@ -7,19 +7,17 @@ import (
 )
 
 type FreeIpAddrTracker struct {
-	networkName string
 	subnet *net.IPNet
 	takenIps map[string]bool
 }
 
-func NewFreeIpAddrTracker(networkName string, subnetMask string) (ipAddrTracker *FreeIpAddrTracker, err error) {
+func NewFreeIpAddrTracker(subnetMask string) (ipAddrTracker *FreeIpAddrTracker, err error) {
 	_, ipv4Net, err := net.ParseCIDR(subnetMask)
 	if err != nil {
 		return nil, stacktrace.Propagate(err, "Failed to parse subnet %s as CIDR.", subnetMask)
 	}
 	takenIps := map[string]bool{}
 	ipAddrTracker = &FreeIpAddrTracker{
-		networkName: networkName,
 		subnet: ipv4Net,
 		takenIps: takenIps,
 	}

--- a/initializer/test_suite_runner.go
+++ b/initializer/test_suite_runner.go
@@ -80,10 +80,7 @@ func (runner TestSuiteRunner) RunTests() (err error) {
 			stacktrace.Propagate(err, "Unable to get network config from config provider")
 		}
 
-		testInstanceUuid := uuid.Generate()
-		// TODO push the network name generation lower??
-		networkName := fmt.Sprintf("%v-%v", testName, testInstanceUuid.String())
-		publicIpProvider, err := testnet.NewFreeIpAddrTracker(networkName, DEFAULT_SUBNET_MASK)
+		publicIpProvider, err := testnet.NewFreeIpAddrTracker(DEFAULT_SUBNET_MASK)
 		if err != nil {
 			return stacktrace.Propagate(err, "")
 		}
@@ -93,6 +90,7 @@ func (runner TestSuiteRunner) RunTests() (err error) {
 			return stacktrace.Propagate(err, "Unable to create network for test '%v'", testName)
 		}
 
+		testInstanceUuid := uuid.Generate()
 		err = runControllerContainer(dockerManager, runner.testControllerImageName, publicIpProvider, testName, testInstanceUuid)
 		if err != nil {
 			// TODO we need to clean up the Docker network still!


### PR DESCRIPTION
We're not doing separate-networks-per-test yet, and the networkName isn't actually used