### PR TITLE
Mieubrisse/wait for network startup

### DIFF
--- a/commons/networks/raw_service_network.go
+++ b/commons/networks/raw_service_network.go
@@ -1,7 +1,6 @@
 package networks
 
 type RawServiceNetwork struct {
-	// If Go had generics, we'd make this object genericized and use that as the return type here
 	ServiceIPs map[int]string
 
 	ContainerIds map[int]string

--- a/commons/networks/service_network_config.go
+++ b/commons/networks/service_network_config.go
@@ -273,7 +273,7 @@ func (networkCfg ServiceNetworkConfig) LoadNetwork(rawInfo RawServiceNetwork) (m
 		if err := config.availabilityChecker.WaitForStartup(service, serviceDependencies); err != nil {
 			return nil, stacktrace.Propagate(err, "An error occurred waiting for service %v to start up", serviceId)
 		}
-		logrus.Debugf("Service %v is available")
+		logrus.Debugf("Service %v is available", serviceId)
 	}
 	logrus.Info("Network is available")
 

--- a/commons/networks/service_network_config.go
+++ b/commons/networks/service_network_config.go
@@ -7,6 +7,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type serviceConfig struct {
+	// The Docker image that will be used to run the given service
+	// Nil has a special meaning of "use the image being tested"
+	dockerImage *string
+	availabilityChecker services.ServiceAvailabilityChecker
+	initializer services.ServiceFactory
+}
+
 // Builder to ease the declaration of the network state we want
 type ServiceNetworkConfigBuilder struct {
 	// Maps a node to the configuration that will be used to construct it
@@ -27,19 +35,20 @@ type ServiceNetworkConfigBuilder struct {
 	nextServiceId int
 
 	// Factories that will be used to construct the nodes at build time
-	configurations map[int]services.ServiceFactory
+	configurations map[int]serviceConfig
 
-	// Tracks the next service configuration ID that will be doled out upon a call to AddServiceConfiguration
+	// Tracks the next service configuration ID that will be doled out upon a call to AddStaticImageConfiguration
 	nextConfigurationId int
 
 }
 
 func NewServiceNetworkConfigBuilder() *ServiceNetworkConfigBuilder {
+	// TODO use aliased struct types to make it clear which IDs are which
 	serviceConfigs := make(map[int]int)
 	serviceDependencies := make(map[int]map[int]bool)
 	serviceStartOrder := make([]int, 0)
 	onlyDependentServices := make(map[int]bool)
-	configurations := make(map[int]services.ServiceFactory)
+	configurations := make(map[int]serviceConfig)
 	return &ServiceNetworkConfigBuilder{
 		serviceConfigs:      serviceConfigs,
 		serviceDependencies: serviceDependencies,
@@ -51,12 +60,29 @@ func NewServiceNetworkConfigBuilder() *ServiceNetworkConfigBuilder {
 	}
 }
 
-// Adds a service configuration to the network, that can be referenced later with AddService
-func (builder *ServiceNetworkConfigBuilder) AddServiceConfiguration(factory services.ServiceFactory) int {
+// Adds a service configuration to the network that will run a static Docker image
+// This configuration can be referenced later with AddService
+func (builder *ServiceNetworkConfigBuilder) AddStaticImageConfiguration(
+		dockerImage *string,
+		initializerCore services.ServiceFactoryConfig,
+		availabilityCheckerCore services.ServiceAvailabilityCheckerCore) int {
+	serviceConfig := serviceConfig{
+		dockerImage: dockerImage,
+		availabilityChecker: *services.NewServiceAvailabilityChecker(availabilityCheckerCore),
+		initializer:         *services.NewServiceFactory(initializerCore),
+	}
 	configurationId := builder.nextConfigurationId
 	builder.nextConfigurationId = builder.nextConfigurationId + 1
-	builder.configurations[configurationId] = factory
+	builder.configurations[configurationId] = serviceConfig
 	return configurationId
+}
+
+// Adds a service configuration to the network that will run the Docker image being tested
+// This configuration can be referenced later with AddService
+func (builder *ServiceNetworkConfigBuilder) AddTestImageConfiguration(
+		initializerCore services.ServiceFactoryConfig,
+		availabilityCheckerCore services.ServiceAvailabilityCheckerCore) int {
+	return builder.AddStaticImageConfiguration(nil, initializerCore, availabilityCheckerCore)
 }
 
 // Adds a serivce to the graph, with the specified dependencies (with the map used only as a set - the values are ignored)
@@ -122,9 +148,9 @@ func (builder ServiceNetworkConfigBuilder) Build() *ServiceNetworkConfig {
 		onlyDependentServicesCopy[dependencyId] = true
 	}
 
-	configurationsCopy := make(map[int]services.ServiceFactory)
-	for configurationId, factory := range builder.configurations {
-		configurationsCopy[configurationId] = factory
+	configurationsCopy := make(map[int]serviceConfig)
+	for configurationId, config := range builder.configurations {
+		configurationsCopy[configurationId] = config
 	}
 
 	return &ServiceNetworkConfig{
@@ -145,7 +171,7 @@ type ServiceNetworkConfig struct {
 	// push that to the implementer of the network (make them do the calls based off what they know)
 	// Don't want to rip it out yet though because it was a pain to put in
 	onlyDependentServices map[int]bool
-	configurations map[int]services.ServiceFactory
+	configurations map[int]serviceConfig
 }
 
 /*
@@ -157,24 +183,21 @@ Returns:
 		user of this method should check if the error result is set and, if so, shut down the running containers!
  */
 // TODO use the network name to create a new network!!
-func (networkCfg ServiceNetworkConfig) CreateAndRun(publicIpProvider *FreeIpAddrTracker, manager *docker.DockerManager) (*RawServiceNetwork, error) {
+func (networkCfg ServiceNetworkConfig) CreateNetwork(testImage string, publicIpProvider *FreeIpAddrTracker, manager *docker.DockerManager) (*RawServiceNetwork, error) {
 	runningServices := make(map[int]services.Service)
 	serviceIps := make(map[int]string)
 	serviceContainerIds := make(map[int]string)
 	allServiceDependencies := make(map[int][]services.Service)
 
 	// First pass: start all services
-	logrus.Info("Starting test network containers...")
+	logrus.Info("Creating & starting test network containers...")
 	for _, serviceId := range networkCfg.servicesStartOrder {
-		serviceDependenciesIds := networkCfg.serviceDependencies[serviceId]
-		serviceDependencies := make([]services.Service, 0, len(serviceDependenciesIds))
-		for dependencyId, _ := range serviceDependenciesIds {
-			// We're guaranteed that this dependency will already be running due to the ordering we enforce in the builder
-			serviceDependencies = append(serviceDependencies, runningServices[dependencyId])
-		}
+		serviceDependencies := networkCfg.getServiceDependencies(serviceId, runningServices)
 
-		configId := networkCfg.serviceConfigs[serviceId]
-		factory := networkCfg.configurations[configId]
+		config, err := networkCfg.getServiceConfig(serviceId)
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "Could not get service config for service ID %v", serviceId)
+		}
 
 		staticIp, err := publicIpProvider.GetFreeIpAddr()
 		if err != nil {
@@ -184,12 +207,17 @@ func (networkCfg ServiceNetworkConfig) CreateAndRun(publicIpProvider *FreeIpAddr
 			}, stacktrace.Propagate(err, "Failed to allocate static IP for service %d", serviceId)
 		}
 
-		service, containerId, err := factory.Construct(staticIp, manager, serviceDependencies)
+		dockerImagePtr := config.dockerImage
+		if dockerImagePtr == nil {
+			dockerImagePtr = &testImage
+		}
+
+		service, containerId, err := config.initializer.Construct(*dockerImagePtr, staticIp, manager, serviceDependencies)
 		if err != nil {
 			return &RawServiceNetwork{
 				ServiceIPs:   serviceIps,
 				ContainerIds: serviceContainerIds,
-			}, stacktrace.Propagate(err, "Failed to construct service from factory")
+			}, stacktrace.Propagate(err, "Failed to construct service from serviceConfig")
 		}
 
 		runningServices[serviceId] = service
@@ -197,28 +225,85 @@ func (networkCfg ServiceNetworkConfig) CreateAndRun(publicIpProvider *FreeIpAddr
 		serviceContainerIds[serviceId] = containerId
 		allServiceDependencies[serviceId] = serviceDependencies
 	}
-	logrus.Info("Test network containers started")
+	logrus.Info("Test network containers created & started")
 
-	startedNetwork := RawServiceNetwork{
+	return &RawServiceNetwork{
 		ServiceIPs:   serviceIps,
 		ContainerIds: serviceContainerIds,
+	}, nil
+}
+
+// Intended for use by the test controller
+// Reads basic information about the nodes in the network and uses the topology information stored
+//  in this object to:
+//		1) translate each IP into the appropriate service using the constructors given in this object and
+//		2) wait until all services are available
+func (networkCfg ServiceNetworkConfig) LoadNetwork(rawInfo RawServiceNetwork) (map[int]services.Service, error) {
+	// First pass: construct the instantions of each service object
+	logrus.Info("Loading services from IPs...")
+	runningServices := make(map[int]services.Service)
+	for _, serviceId := range networkCfg.servicesStartOrder {
+
+		ipAddr, found := rawInfo.ServiceIPs[serviceId]
+		if !found {
+			return nil, stacktrace.NewError("Missing expected service ID '%v' in network info", serviceId)
+		}
+
+		config, err := networkCfg.getServiceConfig(serviceId)
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "Could not get service config for service ID %v", serviceId)
+		}
+
+		service := config.initializer.LoadService(ipAddr)
+		runningServices[serviceId] = service
 	}
+	logrus.Info("All services loaded from IPs")
 
 	// Second pass: wait for all services to come up
 	logrus.Info("Waiting for network to become available...")
 	for _, serviceId := range networkCfg.servicesStartOrder {
 		service := runningServices[serviceId]
-		serviceDependencies := allServiceDependencies[serviceId]
-		configId := networkCfg.serviceConfigs[serviceId]
-		factory := networkCfg.configurations[configId]
+		serviceDependencies := networkCfg.getServiceDependencies(serviceId, runningServices)
+		config, err := networkCfg.getServiceConfig(serviceId)
+		if err != nil {
+			return nil, stacktrace.Propagate(err, "Could not get service config for ID %v", serviceId)
+		}
 
 		logrus.Debugf("Waiting for service %v to become available...", serviceId)
-		if err := factory.WaitForStartup(service, serviceDependencies); err != nil {
-			return &startedNetwork, stacktrace.Propagate(err, "An error occurred waiting for service %v to start up", serviceId)
+		if err := config.availabilityChecker.WaitForStartup(service, serviceDependencies); err != nil {
+			return nil, stacktrace.Propagate(err, "An error occurred waiting for service %v to start up", serviceId)
 		}
 		logrus.Debugf("Service %v is available")
 	}
 	logrus.Info("Network is available")
 
-	return &startedNetwork, nil
+	return runningServices, nil
+}
+
+// Convenience function to get a service's dependencies as a []Service
+func (networkCfg ServiceNetworkConfig) getServiceDependencies(serviceId int, runningServices map[int]services.Service) []services.Service {
+	serviceDependenciesIds := networkCfg.serviceDependencies[serviceId]
+	serviceDependencies := make([]services.Service, 0, len(serviceDependenciesIds))
+	for dependencyId, _ := range serviceDependenciesIds {
+		// We're guaranteed that this dependency will already be running due to the ordering we enforce in the builder
+		serviceDependencies = append(serviceDependencies, runningServices[dependencyId])
+	}
+	return serviceDependencies
+}
+
+// Convenience function to get a service's serviceConfig
+func (networkCfg ServiceNetworkConfig) getServiceConfig(serviceId int) (serviceConfig, error) {
+	configId, found := networkCfg.serviceConfigs[serviceId]
+	if !found {
+		return serviceConfig{}, stacktrace.NewError("Found ID '%v' in the network info but no configuration is defined for this ID in the network config", serviceId)
+	}
+
+	config, found := networkCfg.configurations[configId]
+	if !found {
+		return serviceConfig{}, stacktrace.NewError(
+			"Service ID '%v' uses service configuration '%v', but this service config wasn't found in this network configuration; this is likely a code problem",
+			serviceId,
+			configId)
+	}
+	return config, nil
 }

--- a/commons/networks/service_network_config_test.go
+++ b/commons/networks/service_network_config_test.go
@@ -49,7 +49,7 @@ func TestDisallowingNonexistentConfigs(t *testing.T) {
 
 func TestDisallowingNonexistentDependencies(t *testing.T) {
 	builder := NewServiceNetworkConfigBuilder()
-	config := builder.AddServiceConfiguration(*getTestServiceFactory())
+	config := builder.AddStaticImageConfiguration(*getTestServiceFactory())
 
 	dependencies := map[int]bool{
 		0: true,
@@ -65,7 +65,7 @@ func TestDisallowingNonexistentDependencies(t *testing.T) {
 
 func TestIdsDifferent(t *testing.T) {
 	builder := NewServiceNetworkConfigBuilder()
-	config := builder.AddServiceConfiguration(*getTestServiceFactory())
+	config := builder.AddStaticImageConfiguration(*getTestServiceFactory())
 	svc1, err := builder.AddService(config, make(map[int]bool))
 	if err != nil {
 		t.Fatal("Add service shouldn't return error here")
@@ -79,7 +79,7 @@ func TestIdsDifferent(t *testing.T) {
 
 func TestDependencyBookkeeping(t *testing.T) {
 	builder := NewServiceNetworkConfigBuilder()
-	config := builder.AddServiceConfiguration(*getTestServiceFactory())
+	config := builder.AddStaticImageConfiguration(*getTestServiceFactory())
 
 	svc1, err := builder.AddService(config, make(map[int]bool))
 	if err != nil {
@@ -145,7 +145,7 @@ func TestDependencyBookkeeping(t *testing.T) {
 
 func TestDefensiveCopies(t *testing.T) {
 	builder := NewServiceNetworkConfigBuilder()
-	config := builder.AddServiceConfiguration(*getTestServiceFactory())
+	config := builder.AddStaticImageConfiguration(*getTestServiceFactory())
 
 	dependencyMap := make(map[int]bool)
 	svc1, err := builder.AddService(config, dependencyMap)
@@ -155,7 +155,7 @@ func TestDefensiveCopies(t *testing.T) {
 
 	networkConfig := builder.Build()
 
-	_ = builder.AddServiceConfiguration(*getTestServiceFactory())
+	_ = builder.AddStaticImageConfiguration(*getTestServiceFactory())
 	_, err = builder.AddService(config, make(map[int]bool))
 	if err != nil {
 		t.Fatal("Add service shouldn't return error here")

--- a/commons/networks/service_network_config_test.go
+++ b/commons/networks/service_network_config_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/kurtosis-tech/kurtosis/commons/services"
 	"gotest.tools/assert"
 	"testing"
+	"time"
 )
 
 
@@ -24,6 +25,14 @@ func (t TestFactoryConfig) GetStartCommand(publicIpAddr string, dependencies []s
 
 func (t TestFactoryConfig) GetServiceFromIp(ipAddr string) services.Service {
 	return TestService{}
+}
+
+func (t TestFactoryConfig) IsServiceUp(toCheck services.Service, dependencies []services.Service) bool {
+	return true
+}
+
+func (t TestFactoryConfig) GetStartupTimeout() time.Duration {
+	return 30 * time.Second
 }
 
 func getTestServiceFactory() *services.ServiceFactory {

--- a/commons/services/service.go
+++ b/commons/services/service.go
@@ -1,5 +1,3 @@
 package services
 
-// Because Go doesn't have generics, we use this hopefully as an indicator for people to implement their own version of
-// this once
 type Service interface {}

--- a/commons/services/service_availability_checker.go
+++ b/commons/services/service_availability_checker.go
@@ -1,0 +1,34 @@
+package services
+
+import (
+	"github.com/palantir/stacktrace"
+	"github.com/sirupsen/logrus"
+	"time"
+)
+
+const (
+	TIME_BETWEEN_STARTUP_POLLS = 1 * time.Second
+)
+
+type ServiceAvailabilityChecker struct {
+	core ServiceAvailabilityCheckerCore
+}
+
+func NewServiceAvailabilityChecker(core ServiceAvailabilityCheckerCore) *ServiceAvailabilityChecker {
+	return &ServiceAvailabilityChecker{core: core}
+}
+
+// Waits for the given service to start up by making requests (configured by the core) to the service until the service
+//  is reported as up or the timeout is reached
+func (checker ServiceAvailabilityChecker) WaitForStartup(toCheck Service, dependencies []Service) error {
+	startupTimeout := checker.core.GetTimeout()
+	pollStartTime := time.Now()
+	for time.Since(pollStartTime) < startupTimeout {
+		if checker.core.IsServiceUp(toCheck, dependencies) {
+			return nil
+		}
+		logrus.Tracef("Service is not yet available; sleeping for %v before retrying...", TIME_BETWEEN_STARTUP_POLLS)
+		time.Sleep(TIME_BETWEEN_STARTUP_POLLS)
+	}
+	return stacktrace.NewError("Hit timeout (%v) while waiting for service to start", startupTimeout)
+}

--- a/commons/services/service_availability_checker_core.go
+++ b/commons/services/service_availability_checker_core.go
@@ -1,0 +1,13 @@
+package services
+
+import "time"
+
+// TODO When Go has generics, parameterize this to be <N, S extends N> where S is the
+//  specific service interface and N represents the interface that every node on the network has
+type ServiceAvailabilityCheckerCore interface {
+	// TODO When Go gets generics, make the type of these args 'toCheck S' and 'dependencies []N'
+	IsServiceUp(toCheck Service, dependencies []Service) bool
+
+	// How long to keep checking for the service to be available before giving up
+	GetTimeout() time.Duration
+}

--- a/commons/services/service_factory.go
+++ b/commons/services/service_factory.go
@@ -3,19 +3,35 @@ package services
 import (
 	"github.com/kurtosis-tech/kurtosis/commons/docker"
 	"github.com/palantir/stacktrace"
+	"time"
 )
 
+const (
+	TIME_BETWEEN_STARTUP_POLLS_STR = "1s"
+)
+
+// TODO Rename to ServiceInitializer
 // This implicitly is a Docker container factory, but we could abstract to other backends if we wanted later
 type ServiceFactory struct {
 	config ServiceFactoryConfig
+	timeBetweenStartupPolls time.Duration
 }
 
-func NewServiceFactory(config ServiceFactoryConfig) *ServiceFactory {
+func NewServiceFactory(config ServiceFactoryConfig) (*ServiceFactory, error) {
+	timeBetweenStartupPolls, err := time.ParseDuration(TIME_BETWEEN_STARTUP_POLLS_STR)
+	if err != nil {
+		return nil, stacktrace.Propagate(
+			err,
+			"Could not parse string indicating time between startup polls '%v'; this is likely a code problem",
+			TIME_BETWEEN_STARTUP_POLLS_STR)
+	}
 	return &ServiceFactory{
 		config: config,
-	}
+		timeBetweenStartupPolls: timeBetweenStartupPolls,
+	}, nil
 }
 
+// TODO Rename to NewInstance
 // If Go had generics, this would be genericized so that the arg type = return type
 func (factory ServiceFactory) Construct(
 			staticIp string,
@@ -40,4 +56,18 @@ func (factory ServiceFactory) Construct(
 		return nil, "", stacktrace.Propagate(err, "Could not start docker service for image %v", dockerImage)
 	}
 	return factory.config.GetServiceFromIp(ipAddr), containerId, nil
+}
+
+// Waits for the given service to start up by making requests (configured by the core) to the service until the service
+//  is reported as up or the timeout is reached
+func (factory ServiceFactory) WaitForStartup(toCheck Service, dependencies []Service) error {
+	startupTimeoutMillis := factory.config.GetStartupTimeoutMillis()
+	pollStartTime := time.Now()
+	for time.Since(pollStartTime).Milliseconds() < startupTimeoutMillis {
+		if factory.config.IsServiceUp(toCheck, dependencies) {
+			return nil
+		}
+		time.Sleep(factory.timeBetweenStartupPolls)
+	}
+	return stacktrace.NewError("Hit timeout (%v) while waiting for service to start")
 }

--- a/commons/services/service_factory.go
+++ b/commons/services/service_factory.go
@@ -60,5 +60,5 @@ func (factory ServiceFactory) WaitForStartup(toCheck Service, dependencies []Ser
 		}
 		time.Sleep(TIME_BETWEEN_STARTUP_POLLS)
 	}
-	return stacktrace.NewError("Hit timeout (%v) while waiting for service to start")
+	return stacktrace.NewError("Hit timeout (%v) while waiting for service to start", startupTimeout)
 }

--- a/commons/services/service_factory.go
+++ b/commons/services/service_factory.go
@@ -3,6 +3,7 @@ package services
 import (
 	"github.com/kurtosis-tech/kurtosis/commons/docker"
 	"github.com/palantir/stacktrace"
+	"github.com/sirupsen/logrus"
 	"time"
 )
 
@@ -58,6 +59,7 @@ func (factory ServiceFactory) WaitForStartup(toCheck Service, dependencies []Ser
 		if factory.config.IsServiceUp(toCheck, dependencies) {
 			return nil
 		}
+		logrus.Tracef("Service is not yet available; sleeping for %v before retrying...", TIME_BETWEEN_STARTUP_POLLS)
 		time.Sleep(TIME_BETWEEN_STARTUP_POLLS)
 	}
 	return stacktrace.NewError("Hit timeout (%v) while waiting for service to start", startupTimeout)

--- a/commons/services/service_factory_config.go
+++ b/commons/services/service_factory_config.go
@@ -1,5 +1,7 @@
 package services
 
+import "time"
+
 // TODO Rename this ServiceInitializerCore
 // Contains configuration determining what type of objects the ServiceFactory will produce
 // This is implicitly a DockerContainerServiceFactoryConfig; we could abstract it easily if we wanted other foundations for services
@@ -25,6 +27,6 @@ type ServiceFactoryConfig interface {
 	IsServiceUp(toCheck Service, dependencies []Service) bool
 
 	// How long to wait for the service to start up before giving up
-	GetStartupTimeoutMillis() int64
+	GetStartupTimeout() time.Duration
 }
 

--- a/commons/services/service_factory_config.go
+++ b/commons/services/service_factory_config.go
@@ -1,32 +1,18 @@
 package services
 
-import "time"
-
 // TODO Rename this ServiceInitializerCore
+// TODO When Go has generics, parameterize this to be <N, S extends N> where S is the
+//  specific service interface and N represents the interface that every node on the network has
 // Contains configuration determining what type of objects the ServiceFactory will produce
 // This is implicitly a DockerContainerServiceFactoryConfig; we could abstract it easily if we wanted other foundations for services
 type ServiceFactoryConfig interface {
-	GetDockerImage() string
-
 	GetUsedPorts() map[int]bool
 
-	// TODO when Go gets generics, make the type of 'dependencies' be the same as the output of GetStartCommand
+	// TODO when Go gets generics, make the type of 'dependencies' to be []N
 	// If Go had generics, dependencies should be of type []T
 	GetStartCommand(publicIpAddr string, dependencies []Service) []string
 
-	// If Go had generics, the return type would be T
+	// TODO When Go has generics, make this return type to be S
 	GetServiceFromIp(ipAddr string) Service
-
-	// ========================================================================================
-	// NOTE: These functions below for checking liveness will probably need to be moved to a separate
-	//  LivenessChecker object or to the Service itself; they live right here for now because it makes implementing the
-	//  API very easy - the user just defines one ServiceFactoryConfig implementation. The impetus for moving
-	//  this would be when topology needs to be dynamic at testing time (i.e. a test can start and stop nodes)
-
-	// TODO When Go gets generics, make the type of these args parameterized
-	IsServiceUp(toCheck Service, dependencies []Service) bool
-
-	// How long to wait for the service to start up before giving up
-	GetStartupTimeout() time.Duration
 }
 

--- a/commons/services/service_factory_config.go
+++ b/commons/services/service_factory_config.go
@@ -1,5 +1,6 @@
 package services
 
+// TODO Rename this ServiceInitializerCore
 // Contains configuration determining what type of objects the ServiceFactory will produce
 // This is implicitly a DockerContainerServiceFactoryConfig; we could abstract it easily if we wanted other foundations for services
 type ServiceFactoryConfig interface {
@@ -13,5 +14,17 @@ type ServiceFactoryConfig interface {
 
 	// If Go had generics, the return type would be T
 	GetServiceFromIp(ipAddr string) Service
+
+	// ========================================================================================
+	// NOTE: These functions below for checking liveness will probably need to be moved to a separate
+	//  LivenessChecker object or to the Service itself; they live right here for now because it makes implementing the
+	//  API very easy - the user just defines one ServiceFactoryConfig implementation. The impetus for moving
+	//  this would be when topology needs to be dynamic at testing time (i.e. a test can start and stop nodes)
+
+	// TODO When Go gets generics, make the type of these args parameterized
+	IsServiceUp(toCheck Service, dependencies []Service) bool
+
+	// How long to wait for the service to start up before giving up
+	GetStartupTimeoutMillis() int64
 }
 

--- a/commons/testsuite/test.go
+++ b/commons/testsuite/test.go
@@ -5,5 +5,6 @@ type Test interface {
 	// as produced by the TestNetworkLoader
 	Run(network interface{}, context TestContext)
 
+	// TODO Rename to GetServiceNetworkConfigurator
 	GetNetworkLoader() TestNetworkLoader
 }

--- a/commons/testsuite/test_network_loader.go
+++ b/commons/testsuite/test_network_loader.go
@@ -2,16 +2,15 @@ package testsuite
 
 import (
 	"github.com/kurtosis-tech/kurtosis/commons/networks"
+	"github.com/kurtosis-tech/kurtosis/commons/services"
 )
 
-/*
-This interface should be implemented by the user and is responsible for:
-1) creating a network config so that the initializer can use it to create a network and
-2) parsing the RawServiceNetwork object passed over to the TestController to create the actual network the test will  receive
- */
+// This class is intended to provide an easy place to capture the specifics of configuring a network
 type TestNetworkLoader interface {
-	GetNetworkConfig(testImageName string) (*networks.ServiceNetworkConfig, error)
+	GetNetworkConfig() (*networks.ServiceNetworkConfig, error)
 
-	// If Go had generics, this return type would be parameterized to be the actual type of network a test will consume
-	LoadNetwork(ipAddrs map[int]string) (interface{}, error)
+	// TODO When Go has generics, make the input and output types parameterized
+	// Wraps the map of service_id -> service with a user-custom object representing the network, so the user can expose
+	//  whatever methods they please so writing tests is as simple as possible
+	WrapNetwork(services map[int]services.Service) (interface{}, error)
 }

--- a/controller/test_controller.go
+++ b/controller/test_controller.go
@@ -43,10 +43,18 @@ func (controller TestController) RunTests(testName string, networkInfoFilepath s
 	if err != nil {
 		return false, stacktrace.Propagate(err, "Decoding raw service network information failed for file: %v", networkInfoFilepath)
 	}
-	untypedNetwork, err := test.GetNetworkLoader().LoadNetwork(rawServiceNetwork.ServiceIPs)
+
+	networkLoader := test.GetNetworkLoader()
+
+	networkCfg, err := networkLoader.GetNetworkConfig()
 	if err != nil {
-		return false, stacktrace.Propagate(err, "Unable to load network from service IPs")
+		return false, stacktrace.Propagate(err, "Could not get test network config")
 	}
+	serviceNetwork, err := networkCfg.LoadNetwork(rawServiceNetwork)
+	if err != nil {
+		return false, stacktrace.Propagate(err, "Could not load network from raw service information")
+	}
+	untypedNetwork, err := networkLoader.WrapNetwork(serviceNetwork)
 
 	testSucceeded := true
 	context := testsuite.TestContext{}

--- a/initializer/test_suite_runner.go
+++ b/initializer/test_suite_runner.go
@@ -87,7 +87,7 @@ func (runner TestSuiteRunner) RunTests() (err error) {
 	for testName, test := range tests {
 		logrus.Infof("Running test: %v", testName)
 		networkLoader := test.GetNetworkLoader()
-		testNetworkCfg, err := networkLoader.GetNetworkConfig(runner.testServiceImageName)
+		testNetworkCfg, err := networkLoader.GetNetworkConfig()
 		if err != nil {
 			return stacktrace.Propagate(err, "Unable to get network test from test provider")
 		}
@@ -97,14 +97,12 @@ func (runner TestSuiteRunner) RunTests() (err error) {
 		if err != nil {
 			return stacktrace.Propagate(err, "")
 		}
-		serviceNetwork, err := testNetworkCfg.CreateAndRun(publicIpProvider, dockerManager)
+		serviceNetwork, err := testNetworkCfg.CreateNetwork(runner.testServiceImageName, publicIpProvider, dockerManager)
 		if err != nil {
 			stopNetwork(dockerManager, serviceNetwork, &containerStopTimeout)
 			return stacktrace.Propagate(err, "Unable to create network for test '%v'", testName)
 		}
 		logrus.Info("Network created successfully")
-
-		// TODO wait for network to completely start up before running the container!
 
 		err = runControllerContainer(
 			dockerManager,


### PR DESCRIPTION
Refactors with a couple improvements:
1) make the NetworkCfg be the class that deals with both instantiating the network (inside initializer) and loading-from-IPs-and-waiting-for-startup (inside controller)
2) allow users to define their network with "don't fill in an image in code; use it passed in at test time" (this is what allows us to do the GetNetworkConfig() call in the controller - it previously used to require a testImage, which the controller doesn't have)
3) Add LoadNetwork call in the SvcNetworkCfg, which does the create-network-from-IPs-and-wait-for-startup (intended to be run in the controller)
4) Added a ServiceAvailabilityChecker, analogous to ServiceFactory, with a ServiceAvailabilityCheckerCore that needs to be defined by the user, analogous to ServiceFactoryConfig.

NOTE: We need to rename ServiceFactory -> ServiceInitializer (because it doesn't just construct instance in the initializer; it also loads them from IPs for the controller) and ServiceFactoryConfig -> ServiceInitializerCore (which will better accommodate the file-binding changes that you're doing now). To keep this PR smaller, I didn't do these now but you'll see things like:
```
initializerCore := NewServiceFactoryConfig() // This doesn't match because it's not renamed yet
```