### PR TITLE
Gmarchetti/flexible env vars for controller

### DIFF
--- a/commons/docker/docker_manager.go
+++ b/commons/docker/docker_manager.go
@@ -289,6 +289,8 @@ func (manager DockerManager) connectToNetwork(networkName string, containerId st
 
 func (manager DockerManager) pullImage(imageName string) (err error) {
 	manager.log.Infof("Pulling image %s...", imageName)
+	manager.log.Debugf("Image name is: %s...", imageName)
+	manager.log.Infof("Image name is: %s...", imageName)
 	out, err := manager.dockerClient.ImagePull(manager.dockerCtx, imageName, types.ImagePullOptions{})
 	if err != nil {
 		return stacktrace.Propagate(err, "Failed to pull image %s", imageName)

--- a/commons/docker/docker_manager.go
+++ b/commons/docker/docker_manager.go
@@ -289,8 +289,8 @@ func (manager DockerManager) connectToNetwork(networkName string, containerId st
 
 func (manager DockerManager) pullImage(imageName string) (err error) {
 	manager.log.Infof("Pulling image %s...", imageName)
-	manager.log.Debugf("Image name is: %s...", imageName)
-	manager.log.Infof("Image name is: %s...", imageName)
+	logrus.Debugf("Image name is: %s...", imageName)
+	logrus.Infof("Image name is: %s...", imageName)
 	out, err := manager.dockerClient.ImagePull(manager.dockerCtx, imageName, types.ImagePullOptions{})
 	if err != nil {
 		return stacktrace.Propagate(err, "Failed to pull image %s", imageName)

--- a/commons/docker/docker_manager.go
+++ b/commons/docker/docker_manager.go
@@ -289,8 +289,6 @@ func (manager DockerManager) connectToNetwork(networkName string, containerId st
 
 func (manager DockerManager) pullImage(imageName string) (err error) {
 	manager.log.Infof("Pulling image %s...", imageName)
-	logrus.Debugf("Image name is: %s...", imageName)
-	logrus.Infof("Image name is: %s...", imageName)
 	out, err := manager.dockerClient.ImagePull(manager.dockerCtx, imageName, types.ImagePullOptions{})
 	if err != nil {
 		return stacktrace.Propagate(err, "Failed to pull image %s", imageName)

--- a/initializer/parallelism/test_executor.go
+++ b/initializer/parallelism/test_executor.go
@@ -276,7 +276,7 @@ func generateTestControllerEnvVariables(
 		testVolumeArg:           testVolumeName,
 		testVolumeMountpointArg: testVolumeMountpoint,
 	}
-	for key, val := range(envVars) {
+	for key, val := range envVars {
 		standardVars[key] = val
 	}
 	return standardVars

--- a/initializer/parallelism/test_executor.go
+++ b/initializer/parallelism/test_executor.go
@@ -256,6 +256,7 @@ Args:
 	testServiceImageName: The name of the Docker image of the service that we're testing
 	testVolumeName: The name of the Docker volume that has been created for this particular test execution, and that the
 		test controller can share with the services that it spins up to read and write data to them
+	envVars: A custom user-defined map from <env variable name> -> <env variable value> that will be set for test controller
 */
 func generateTestControllerEnvVariables(
 			networkName string,

--- a/initializer/parallelism/test_executor.go
+++ b/initializer/parallelism/test_executor.go
@@ -63,6 +63,7 @@ func (executor testExecutor) runTest(
 		testControllerImageName string,
 		testControllerLogLevel string,
 		testServiceImageName string,
+		testControllerEnvVars map[string]string,
 		testName string) (bool, error) {
 	executor.log.Info("Creating Docker manager from environment settings...")
 	dockerManager, err := docker.NewDockerManager(executor.log, testContext, dockerClient)
@@ -103,6 +104,7 @@ func (executor testExecutor) runTest(
 		testControllerImageName,
 		testControllerLogLevel,
 		testServiceImageName,
+		testControllerEnvVars,
 		testName,
 		executionInstanceId)
 	if err != nil {
@@ -146,6 +148,7 @@ func runControllerContainer(
 			controllerImageName string,
 			logLevel string,
 			testServiceImageName string,
+			testControllerEnvVars map[string]string,
 			testName string,
 			executionUuid uuid.UUID) (bool, error){
 	volumeName := fmt.Sprintf("%v-%v", executionUuid.String(), testName)
@@ -172,7 +175,8 @@ func runControllerContainer(
 		testName,
 		logLevel,
 		testServiceImageName,
-		volumeName)
+		volumeName,
+		testControllerEnvVars)
 	log.Debugf("Environment variables that are being passed to the controller: %v", envVariables)
 
 	_, controllerContainerId, err := manager.CreateAndStartContainer(
@@ -258,8 +262,9 @@ func generateTestControllerEnvVariables(
 			testName string,
 			logLevel string,
 			testServiceImageName string,
-			testVolumeName string) map[string]string {
-	return map[string]string{
+			testVolumeName string,
+			envVars map[string]string) map[string]string {
+	standardVars := map[string]string{
 		testNameArg:             testName,
 		subnetMaskArg:           subnetMask,
 		networkNameArg:          networkName,
@@ -271,4 +276,8 @@ func generateTestControllerEnvVariables(
 		testVolumeArg:           testVolumeName,
 		testVolumeMountpointArg: testVolumeMountpoint,
 	}
+	for key, val := range(envVars) {
+		standardVars[key] = val
+	}
+	return standardVars
 }

--- a/initializer/parallelism/test_executor_parallelizer.go
+++ b/initializer/parallelism/test_executor_parallelizer.go
@@ -45,6 +45,7 @@ Args:
 	dockerClient: The handle to manipulating the Docker environment
 	testControllerImageName: The name of the Docker image that will be used to run the test controller
 	testServiceImageName: The name of the Docker image of the version of the service being tested
+	testControllerEnvVars: A custom user-defined map from <env variable name> -> <env variable value> that will be set for test controller
 	parallelism: The number of tests to run concurrently
  */
 func NewTestExecutorParallelizer(

--- a/initializer/parallelism/test_executor_parallelizer.go
+++ b/initializer/parallelism/test_executor_parallelizer.go
@@ -28,12 +28,13 @@ type ParallelTestOutput struct {
 
 // ================= Parallel executor ============================
 type TestExecutorParallelizer struct {
-	executionId uuid.UUID
-	dockerClient *client.Client
+	executionId             uuid.UUID
+	dockerClient            *client.Client
 	testControllerImageName string
-	testControllerLogLevel string
-	testServiceImageName string
-	parallelism uint
+	testControllerLogLevel  string
+	testServiceImageName    string
+	testControllerEnvVars   map[string]string
+	parallelism             uint
 }
 
 /*
@@ -52,14 +53,16 @@ func NewTestExecutorParallelizer(
 			testControllerImageName string,
 			testControllerLogLevel string,
 			testServiceImageName string,
+			testControllerEnvVars map[string]string,
 			parallelism uint) *TestExecutorParallelizer {
 	return &TestExecutorParallelizer{
-		executionId: executionId,
-		dockerClient: dockerClient,
+		executionId:             executionId,
+		dockerClient:            dockerClient,
 		testControllerImageName: testControllerImageName,
-		testControllerLogLevel: testControllerLogLevel,
-		testServiceImageName: testServiceImageName,
-		parallelism: parallelism,
+		testControllerLogLevel:  testControllerLogLevel,
+		testServiceImageName:    testServiceImageName,
+		testControllerEnvVars:   testControllerEnvVars,
+		parallelism:             parallelism,
 	}
 }
 
@@ -140,6 +143,7 @@ func (executor TestExecutorParallelizer) runTestWorker(
 			executor.testControllerImageName,
 			executor.testControllerLogLevel,
 			executor.testServiceImageName,
+			executor.testControllerEnvVars,
 			testParams.TestName)
 
 		result := ParallelTestOutput{

--- a/initializer/test_suite_runner.go
+++ b/initializer/test_suite_runner.go
@@ -30,6 +30,7 @@ type TestSuiteRunner struct {
 	testSuite               testsuite.TestSuite
 	testServiceImageName    string
 	testControllerImageName string
+	testControllerEnvVars   map[string]string
 
 	// The test controller image-specific string representing the log level, that will be passed as-is to the test controller
 	testControllerLogLevel	string
@@ -54,12 +55,14 @@ func NewTestSuiteRunner(
 			testSuite testsuite.TestSuite,
 			testServiceImageName string,
 			testControllerImageName string,
-			testControllerLogLevel string) *TestSuiteRunner {
+			testControllerLogLevel string,
+			testControllerEnvVars map[string]string) *TestSuiteRunner {
 	return &TestSuiteRunner{
 		testSuite:               testSuite,
 		testServiceImageName:    testServiceImageName,
 		testControllerImageName: testControllerImageName,
-		testControllerLogLevel: testControllerLogLevel,
+		testControllerLogLevel:  testControllerLogLevel,
+		testControllerEnvVars:   testControllerEnvVars,
 	}
 }
 
@@ -105,6 +108,7 @@ func (runner TestSuiteRunner) RunTests(testNamesToRun []string, testParallelism 
 		runner.testControllerImageName,
 		runner.testControllerLogLevel,
 		runner.testServiceImageName,
+		runner.testControllerEnvVars,
 		testParallelism)
 
 	logrus.Infof("Running %v tests with execution ID %v...", len(testsToRun), executionInstanceId.String())


### PR DESCRIPTION
This allows writers of test controllers to pass in flexible environment variables from the initializer to the controller. This is particularly important for passing in arbitrary image names for example for byzantine tests