### PR TITLE
Gmarchetti/switch freeipaddrtracker to use ipv6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Added a "Debugging failed tests" tutorial
 * Bugfix for broken CI checks that don't verify CHANGELOG is actually modified
 * Pass network ID instead of network name to the controller
+* Switching FreeIpAddrTracker to pass net.IP objects instead of strings
 
 # 0.7.0
 * Allow developers to configure how wide their test networks will be

--- a/commons/docker/docker_manager.go
+++ b/commons/docker/docker_manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
+	"net"
 	"time"
 )
 
@@ -65,7 +66,7 @@ Args:
 Returns:
 	id: The Docker-managed ID of the network
  */
-func (manager DockerManager) CreateNetwork(context context.Context, name string, subnetMask string, gatewayIP string) (id string, err error)  {
+func (manager DockerManager) CreateNetwork(context context.Context, name string, subnetMask string, gatewayIP net.IP) (id string, err error)  {
 	found, err := manager.networkExists(name)
 	if err != nil {
 		return "", stacktrace.Propagate(err, "An error occurred checking for existence of network with name %v", name)
@@ -77,7 +78,7 @@ func (manager DockerManager) CreateNetwork(context context.Context, name string,
 	}
 	ipamConfig := []network.IPAMConfig{{
 		Subnet: subnetMask,
-		Gateway: gatewayIP,
+		Gateway: gatewayIP.String(),
 	}}
 	resp, err := manager.dockerClient.NetworkCreate(context, name, types.NetworkCreate{
 		Driver: DOCKER_NETWORK_DRIVER,

--- a/commons/networks/public_ip_tracker.go
+++ b/commons/networks/public_ip_tracker.go
@@ -38,7 +38,7 @@ func NewFreeIpAddrTracker(log *logrus.Logger, subnetMask string, alreadyTakenIps
 
 // TODO Return IP objects (which are easily convertable to strings) rather than strings themselves
 // TODO rework this entire function to handle IPv6 as well (currently breaks on IPv6)
-func (networkManager FreeIpAddrTracker) GetFreeIpAddr() (ipAddr string, err error){
+func (networkManager FreeIpAddrTracker) GetFreeIpAddr() (ipAddr net.IP, err error){
 	// convert IPNet struct mask and address to uint32
 	// network is BigEndian
 	mask := binary.BigEndian.Uint32(networkManager.subnet.Mask)
@@ -67,8 +67,8 @@ func (networkManager FreeIpAddrTracker) GetFreeIpAddr() (ipAddr string, err erro
 		ipStr := ip.String()
 		if !networkManager.takenIps[ipStr] {
 			networkManager.takenIps[ipStr] = true
-			return ipStr, nil
+			return ip, nil
 		}
 	}
-	return "", stacktrace.NewError("Failed to allocate IpAddr on subnet %v - all taken.", networkManager.subnet)
+	return nil, stacktrace.NewError("Failed to allocate IpAddr on subnet %v - all taken.", networkManager.subnet)
 }

--- a/commons/networks/service_network.go
+++ b/commons/networks/service_network.go
@@ -7,13 +7,14 @@ import (
 	"github.com/kurtosis-tech/kurtosis/commons/services"
 	"github.com/palantir/stacktrace"
 	"github.com/sirupsen/logrus"
+	"net"
 	"time"
 )
 
 type ServiceID int
 
 type ServiceNode struct {
-	IpAddr string
+	IpAddr net.IP
 
 	// If Go had generics, we'd make this object genericized and use that as the return type here
 	Service services.Service

--- a/commons/networks/service_network_test.go
+++ b/commons/networks/service_network_test.go
@@ -3,6 +3,7 @@ package networks
 import (
 	"github.com/docker/go-connections/nat"
 	"github.com/kurtosis-tech/kurtosis/commons/services"
+	"net"
 	"os"
 	"testing"
 	"time"
@@ -30,7 +31,7 @@ func (t TestInitializerCore) InitializeMountedFiles(filepathsToMount map[string]
 	return nil
 }
 
-func (t TestInitializerCore) GetStartCommand(mountedFileFilepaths map[string]string, publicIpAddr string, dependencies []services.Service) ([]string, error) {
+func (t TestInitializerCore) GetStartCommand(mountedFileFilepaths map[string]string, publicIpAddr net.IP, dependencies []services.Service) ([]string, error) {
 	return make([]string, 0), nil
 }
 

--- a/commons/services/service_initializer.go
+++ b/commons/services/service_initializer.go
@@ -6,6 +6,7 @@ import (
 	"github.com/docker/distribution/uuid"
 	"github.com/kurtosis-tech/kurtosis/commons/docker"
 	"github.com/palantir/stacktrace"
+	"net"
 	"os"
 	"path/filepath"
 )
@@ -41,7 +42,7 @@ func (initializer ServiceInitializer) CreateService(
 			testVolumeName string,
 			testVolumeControllerDirpath string,
 			dockerImage string,
-			staticIp string,
+			staticIp net.IP,
 			manager *docker.DockerManager,
 			dependencies []Service) (Service, string, error) {
 	initializerCore := initializer.core
@@ -92,9 +93,9 @@ func (initializer ServiceInitializer) CreateService(
 	if err != nil {
 		return nil, "", stacktrace.Propagate(err, "Could not start docker service for image %v", dockerImage)
 	}
-	return initializer.core.GetServiceFromIp(ipAddr), containerId, nil
+	return initializer.core.GetServiceFromIp(ipAddr.String()), containerId, nil
 }
 
-func (initializer ServiceInitializer) LoadService(ipAddr string) Service {
-	return initializer.core.GetServiceFromIp(ipAddr)
+func (initializer ServiceInitializer) LoadService(ipAddr net.IP) Service {
+	return initializer.core.GetServiceFromIp(ipAddr.String())
 }

--- a/commons/services/service_initializer_core.go
+++ b/commons/services/service_initializer_core.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"github.com/docker/go-connections/nat"
+	"net"
 	"os"
 )
 
@@ -72,7 +73,7 @@ type ServiceInitializerCore interface {
 		publicIpAddr: The IP address of the Docker image running the service
 		dependencies: The services that this service depends on (for use in case the command line to the service changes based on dependencies)
 	 */
-	GetStartCommand(mountedFileFilepaths map[string]string, publicIpAddr string, dependencies []Service) ([]string, error)
+	GetStartCommand(mountedFileFilepaths map[string]string, publicIpAddr net.IP, dependencies []Service) ([]string, error)
 
 }
 

--- a/initializer/parallelism/test_executor.go
+++ b/initializer/parallelism/test_executor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"time"
 )
@@ -239,8 +240,8 @@ func (executor testExecutor) runControllerContainer(
 			context context.Context,
 			manager *docker.DockerManager,
 			networkName string,
-			gatewayIp string,
-			controllerIpAddr string) (bool, error){
+			gatewayIp net.IP,
+			controllerIpAddr net.IP) (bool, error){
 	uniqueTestIdentifier := fmt.Sprintf("%v-%v", executor.executionInstanceId.String(), executor.testName)
 
 	volumeName := uniqueTestIdentifier
@@ -359,8 +360,8 @@ Args:
 func generateTestControllerEnvVariables(
 			networkName string,
 			subnetMask string,
-			gatewayIp string,
-			controllerIpAddr string,
+			gatewayIp net.IP,
+			controllerIpAddr net.IP,
 			testName string,
 			logLevel string,
 			testVolumeName string,
@@ -369,10 +370,10 @@ func generateTestControllerEnvVariables(
 		testNameArg:             testName,
 		subnetMaskArg:           subnetMask,
 		networkNameArg:          networkName,
-		gatewayIpArg:            gatewayIp,
+		gatewayIpArg:            gatewayIp.String(),
 		logFilepathArg:          controllerLogMountFilepath,
 		logLevelArg:             logLevel,
-		testControllerIpArg:     controllerIpAddr,
+		testControllerIpArg:     controllerIpAddr.String(),
 		testVolumeArg:           testVolumeName,
 		testVolumeMountpointArg: testVolumeMountpoint,
 	}


### PR DESCRIPTION
Allocating IPs with net.IP objects instead of just strings

corresponding PR in ava-e2e-tests: https://github.com/kurtosis-tech/ava-e2e-tests/pull/108
